### PR TITLE
process_transaction: Validate term load

### DIFF
--- a/operator/transaction.php
+++ b/operator/transaction.php
@@ -101,7 +101,10 @@ class transaction extends operator implements transaction_interface
 		}
 
 		$term_id = $this->request->variable('item_number', 0);
-		$term = $this->container->get('stevotvr.groupsub.entity.term')->load($term_id);
+		if(!($term = $this->container->get('stevotvr.groupsub.entity.term')->load($term_id))) {
+			error_log("process_transaction: failed to get term for term_id=".$term_id);
+			return false;
+		}
 
 		$currency = $this->request->variable('mc_currency', '');
 		if ($term->get_currency() !== $currency)


### PR DESCRIPTION
When the term_id has changed (e.g. due to a package update), but an request is still waiting to be processed, this could lead to an error (Have seen 500s probably originated from this piece of code).
This PR fixes this by checking if the term was loaded successfully.